### PR TITLE
Fix translation cancellation

### DIFF
--- a/RevitTranslator/Services/BaseTranslationService.cs
+++ b/RevitTranslator/Services/BaseTranslationService.cs
@@ -32,6 +32,7 @@ public class BaseTranslationService : IRecipient<TokenCancellationRequestedMessa
                     "Translation Service Error");
             return;
         }
+        StrongReferenceMessenger.Default.Register(this);
         
         var viewModel = new ProgressWindowViewModel();
         var view = new ProgressWindow(viewModel);
@@ -43,6 +44,8 @@ public class BaseTranslationService : IRecipient<TokenCancellationRequestedMessa
         {
             await Translate();
             UpdateRevitModel();
+            
+            StrongReferenceMessenger.Default.UnregisterAll(this);
         });
     }
 


### PR DESCRIPTION
Translation service was not registered as a recepient, which led to unreceived messages for cancellation request.
Service is now registered on load and unregistered when translation is finished.